### PR TITLE
Add Excel export for recorrido data

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,9 @@
           <label>Seg/pto</label>
           <input id="speed" type="number" min="0.5" step="0.5" value="1.5" style="width:70px" />
         </div>
+        <div class="row">
+          <button id="btnExportRecorrido" class="ghost">⬇️ Exportar Excel</button>
+        </div>
         <div class="row"><span class="muted" id="nowInfo">—</span></div>
       </div>
 
@@ -270,6 +273,7 @@
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 
   <!-- Tu JS -->
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- add a control to export the current recorrido group to an Excel file with progresiva, coordinates, and description
- load the SheetJS library to generate the XLSX download on demand

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7e7c341288322b515b1d9551e0d40