### PR TITLE
Add KMZ export and highlight described recorrido points

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
           <label>Seg/pto</label>
           <input id="speed" type="number" min="0.5" step="0.5" value="1.5" style="width:70px" />
         </div>
+        <div class="row">
+          <button id="btnExportRecorrido" class="ghost">⬇️ Exportar Excel</button>
+          <button id="btnExportKMZ" class="ghost">🌍 Exportar KMZ</button>
+        </div>
         <div class="row"><span class="muted" id="nowInfo">—</span></div>
       </div>
 
@@ -270,6 +274,7 @@
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 
   <!-- Tu JS -->
   <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -53,8 +53,9 @@ button, input, select, textarea{
 #photoContainer img{ max-width:100%; max-height:100%; border-radius:6px; transition: transform .2s ease; }
 
 /* Recorrido: vértices y línea */
-.vtx-default { stroke:#7c2d12; stroke-width:1.5px; fill:#f59e0b; fill-opacity:.95; }
-.vtx-highlight { stroke:#fff !important; stroke-width:2.5px !important; fill:#f97316 !important; }
+.vtx-point { stroke:#0f172a; stroke-width:1.5px; fill:#38bdf8; fill-opacity:.95; }
+.vtx-has-desc { stroke:#7c2d12; fill:#f97316; }
+.vtx-highlight { stroke:#f8fafc !important; stroke-width:2.8px !important; filter:drop-shadow(0 0 4px rgba(148,163,184,.8)); }
 
 /* Busy badge */
 #busyBadge{


### PR DESCRIPTION
## Summary
- add a KMZ export control that zips a KML document with recorrido points, descriptions, and optional route line
- adjust recorrido marker styling to visually differentiate points with descriptions and refine highlighting

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7e7c341288322b515b1d9551e0d40