### PR TITLE
Add attachment support to marcaciones

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,17 @@ function detectField(obj,cands){ const ks=Object.keys(obj||{}); for(const c of c
 function toNumberFlexible(v){ if(v==null) return NaN; if(typeof v==='number') return v; if(typeof v!=='string') return NaN; const n=parseFloat(v.trim().replace(/\s+/g,'').replace(',', '.')); return Number.isFinite(n)?n:NaN; }
 function sanitizePath(s){ return String(s||'').normalize('NFKD').replace(/[^a-zA-Z0-9_\-\/\.]+/g,'-').replace(/--+/g,'-').replace(/^-+|-+$/g,''); }
 
+function formatBytes(bytes){
+  const num = Number(bytes);
+  if (!Number.isFinite(num) || num <= 0) return '';
+  const units = ['B','KB','MB','GB','TB'];
+  let value = num;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1){ value /= 1024; unit++; }
+  const digits = value >= 10 || unit === 0 ? 0 : 1;
+  return `${value.toFixed(digits)} ${units[unit]}`;
+}
+
 /* ===== Loading del visor (por imagen) ===== */
 const viewerLoading = document.getElementById('viewerLoading');
 const viewerLoadingText = document.getElementById('viewerLoadingText');
@@ -104,6 +115,120 @@ function showEmptyViewer(){
   document.getElementById('controlsPhoto').style.display = 'none';
   document.getElementById('controlsRun').style.display = 'none';
   hideViewerLoading();
+}
+
+/* ===== Adjuntos marcaciones ===== */
+const attachmentsModal = document.getElementById('attachmentsModal');
+const attachmentsListEl = document.getElementById('attachmentsList');
+const attachmentPreviewEl = document.getElementById('attachmentPreview');
+const attachmentDownloadEl = document.getElementById('attachmentDownload');
+let marcacionAdjuntosMap = new Map();
+let attachmentsModalState = { marcacionId:null, items:[], selectedId:null };
+
+function normalizeAdjuntos(data){
+  const map = new Map();
+  for (const item of data || []){
+    if (!map.has(item.marcacion_id)) map.set(item.marcacion_id, []);
+    map.get(item.marcacion_id).push(item);
+  }
+  for (const list of map.values()){
+    list.sort((a,b)=> new Date(b.created_at||0) - new Date(a.created_at||0));
+  }
+  return map;
+}
+
+function renderAttachmentPreview(att){
+  if (!attachmentPreviewEl) return;
+  if (!att){
+    attachmentPreviewEl.innerHTML = '<div class="muted">Selecciona un adjunto para previsualizarlo.</div>';
+    if (attachmentDownloadEl){ attachmentDownloadEl.style.display = 'none'; }
+    return;
+  }
+  const url = att.url || att.foto_url || '';
+  const safeUrl = esc(url);
+  const type = (att.content_type || '').toLowerCase();
+  const name = (att.nombre || '').toLowerCase();
+  let html = '';
+  if (type.startsWith('image/')){
+    html = `<img src="${safeUrl}" alt="${esc(att.nombre||'Adjunto')}" loading="lazy">`;
+  } else if (type === 'application/pdf' || name.endsWith('.pdf')){
+    html = `<iframe src="${safeUrl}#toolbar=0" title="${esc(att.nombre||'PDF')}" loading="lazy"></iframe>`;
+  } else {
+    html = `<div class="unavailable"><div class="muted" style="margin-bottom:8px">No se puede previsualizar este tipo de archivo.</div><a href="${safeUrl}" target="_blank" rel="noopener">Abrir en nueva pestaña</a></div>`;
+  }
+  attachmentPreviewEl.innerHTML = html;
+  if (attachmentDownloadEl){
+    attachmentDownloadEl.href = url;
+    attachmentDownloadEl.download = att.nombre || '';
+    attachmentDownloadEl.style.display = url ? 'inline-flex' : 'none';
+  }
+}
+
+function populateAttachmentsList(items){
+  if (!attachmentsListEl) return;
+  if (!items.length){
+    attachmentsListEl.innerHTML = '<div class="muted">No hay adjuntos para esta marcación.</div>';
+    renderAttachmentPreview(null);
+    return;
+  }
+  attachmentsListEl.innerHTML = items.map(att=>{
+    const size = formatBytes(att.size);
+    const meta = [att.content_type||'', size].filter(Boolean).join(' · ');
+    return `<div class="attachments-item" data-id="${att.id}">
+        <div class="name">${esc(att.nombre||'Adjunto')}</div>
+        <div class="meta">${esc(meta)}</div>
+      </div>`;
+  }).join('');
+  Array.from(attachmentsListEl.querySelectorAll('.attachments-item')).forEach(el=>{
+    el.addEventListener('click', ()=>{
+      const id = Number(el.dataset.id);
+      selectAttachmentInModal(id);
+    });
+  });
+}
+
+function selectAttachmentInModal(id){
+  if (!attachmentsModalState?.items?.length) return;
+  const att = attachmentsModalState.items.find(a=>a.id === id);
+  if (!att) return;
+  attachmentsModalState.selectedId = id;
+  if (attachmentsListEl){
+    Array.from(attachmentsListEl.querySelectorAll('.attachments-item')).forEach(el=>{
+      el.classList.toggle('active', Number(el.dataset.id) === id);
+    });
+  }
+  renderAttachmentPreview(att);
+}
+
+function openAttachmentsModal(marcacionId, attachmentId){
+  const row = allMarcs.find(x=>x.id === marcacionId);
+  if (!row) return;
+  attachmentsModalState = { marcacionId, items: row.adjuntos || [], selectedId:null };
+  populateAttachmentsList(attachmentsModalState.items);
+  renderAttachmentPreview(null);
+  if (attachmentsModal){
+    openModal(attachmentsModal);
+  }
+  const firstId = attachmentId || attachmentsModalState.items[0]?.id;
+  if (firstId) selectAttachmentInModal(firstId);
+}
+
+window.__openAdjuntos = (id)=>{ openAttachmentsModal(id); };
+window.__openAdjunto = (id, attId)=>{ openAttachmentsModal(id, attId); };
+
+function buildAttachmentsSnippet(row){
+  const items = row?.adjuntos || [];
+  const title = '<div class="popup-attachments"><span class="title">Adjuntos</span>';
+  if (!items.length){
+    return `${title}<div class="muted">Sin archivos</div></div>`;
+  }
+  const previews = items.slice(0,3).map(att=>`
+      <button onclick="window.__openAdjunto(${row.id},${att.id});return false;">${esc(att.nombre||'Archivo')}</button>
+    `).join('');
+  const more = items.length>3 ? `<div class="muted">+${items.length-3} más…</div>` : '';
+  return `${title}<div class="popup-attachments-list">${previews}</div>${more}
+      <div class="view-all"><button class="ghost" onclick="window.__openAdjuntos(${row.id});return false;">📎 Ver todos (${items.length})</button></div>
+    </div>`;
 }
 
 /* Descarga con progreso (si hay Content-Length) */
@@ -318,9 +443,24 @@ async function loadMarcaciones(){
     .select('id,nombre,descripcion,lat,lng,tipo,foto_url,foto_r2_key,created_at')
     .order('id');
   if(error){ console.error(error); setStatus('Error cargando marcaciones'); return; }
-  allMarcs = data||[];
+  let attachmentsData = [];
+  let attachmentsOk = true;
+  try{
+    const { data:adj, error:adjError } = await supabase
+      .from('marcaciones_adjuntos')
+      .select('id,marcacion_id,nombre,url,r2_key,content_type,size,created_at')
+      .order('created_at', { ascending:false });
+    if (adjError) throw adjError;
+    attachmentsData = adj || [];
+  }catch(adjError){
+    console.error('Error cargando adjuntos de marcaciones', adjError);
+    attachmentsOk = false;
+  }
+  marcacionAdjuntosMap = normalizeAdjuntos(attachmentsData);
+  allMarcs = (data||[]).map(row=>({ ...row, adjuntos: marcacionAdjuntosMap.get(row.id) || [] }));
   for(const row of allMarcs){ addMarcacionMarker(row); }
-  setStatus(`Marcaciones: ${allMarcs.length}`);
+  const statusMsg = attachmentsOk ? `Marcaciones: ${allMarcs.length}` : `Marcaciones: ${allMarcs.length} · adjuntos no disponibles`;
+  setStatus(statusMsg);
   enhanceOverlayControlZoomButtons();
 }
 
@@ -330,6 +470,7 @@ function addMarcacionMarker(row){
   const html = `<b>${esc(row.nombre ?? 'Sin nombre')}</b>${row.descripcion? `<br><em>${esc(row.descripcion)}</em>`:''}
                 <br><small>${esc(row.tipo||'sin imagen')}</small>
                 <br><small>id: ${row.id} · ${lat.toFixed(6)}, ${lng.toFixed(6)}</small>
+                ${buildAttachmentsSnippet(row)}
                 <div style="margin-top:6px"><button class="ghost" onclick="window.__editMark(${row.id});return false;">✎ Editar</button></div>`;
   const m=L.marker([lat,lng],{icon}).bindPopup(html);
   m.on('click', async ()=>{
@@ -360,6 +501,27 @@ window.__editMark = (id)=>{
         <img src="${src}" alt="preview" style="max-width:140px;max-height:90px;border:1px solid #334155;border-radius:6px">
       </a>`;
   } else { prev.textContent = '—'; }
+  const listEl = document.getElementById('emAttachmentsList');
+  if (listEl){
+    const attachments = r.adjuntos || [];
+    listEl.classList.toggle('muted', attachments.length===0);
+    if (!attachments.length){
+      listEl.innerHTML = '<div class="empty">Sin adjuntos</div>';
+    } else {
+      listEl.innerHTML = attachments.map(att=>{
+        const meta = [formatBytes(att.size), att.content_type||''].filter(Boolean).join(' · ');
+        return `<div class="item">
+            <label><input type="checkbox" data-remove-id="${att.id}"> <span>${esc(att.nombre||'Archivo')}</span></label>
+            <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;">
+              ${meta ? `<span class="muted" style="font-size:11px;">${esc(meta)}</span>` : ''}
+              <button type="button" onclick="window.__openAdjunto(${r.id},${att.id});return false;">Ver</button>
+            </div>
+          </div>`;
+      }).join('');
+    }
+  }
+  const editAttInput = document.getElementById('emAttachments');
+  if (editAttInput) editAttInput.value = '';
   openModal(document.getElementById('editMarkModal'));
 };
 
@@ -882,6 +1044,19 @@ async function uploadToR2(workerUrl, keyPath, file){
   if(!res.ok){ const t=await res.text(); throw new Error(`R2 upload HTTP ${res.status}: ${t}`); }
   return res.json(); // { url, key }
 }
+async function deleteFromR2(workerUrl, key){
+  if (!key) return false;
+  try{
+    const form = new FormData();
+    form.append('key', key);
+    const res = await fetch(workerUrl.replace(/\/$/,'') + '/delete', { method:'POST', body: form });
+    if (!res.ok){ const t = await res.text().catch(()=> ''); throw new Error(`R2 delete HTTP ${res.status}: ${t}`); }
+    return true;
+  }catch(err){
+    console.warn('No se pudo eliminar de R2', key, err);
+    return false;
+  }
+}
 async function updateFotoUrl(table,rowId,url,key){
   const endpoint=SUPABASE_URL.replace(/\/$/,'' ) + `/rest/v1/${table}?id=eq.`+encodeURIComponent(rowId);
   const res=await fetch(endpoint,{method:'PATCH',headers:{'apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${SUPABASE_ANON_KEY}`,'Content-Type':'application/json','Prefer':'return=minimal'},body:JSON.stringify({foto_url:url,foto_r2_key:key})});
@@ -976,8 +1151,8 @@ async function uploadGroupCsvAndZip(grupo, rowsCsv, zipFile){
 }
 
 /* ===== Modales genéricos ===== */
-function openModal(mod){ mod.classList.add('show'); }
-function closeModal(mod){ mod.classList.remove('show'); }
+function openModal(mod){ if (!mod) return; mod.classList.add('show'); mod.setAttribute('aria-hidden','false'); }
+function closeModal(mod){ if (!mod) return; mod.classList.remove('show'); mod.setAttribute('aria-hidden','true'); }
 document.querySelectorAll('.modal .backdrop,[data-close]').forEach(el=> el.addEventListener('click', (e)=>{
   const m = e.target.closest('.modal'); if(m) closeModal(m);
 }));
@@ -999,6 +1174,8 @@ map.on('click', (e)=>{
   document.getElementById('mDesc').value = 'Añadido desde el mapa';
   document.getElementById('mTipo').value = '';
   document.getElementById('mFile').value = '';
+  const attInput = document.getElementById('mAttachments');
+  if (attInput) attInput.value = '';
   document.getElementById('markMsg').textContent = '';
   openModal(markModal);
 });
@@ -1010,19 +1187,23 @@ document.getElementById('markForm').addEventListener('submit', async (e)=>{
   const lat=Number(document.getElementById('mLat').value);
   const lng=Number(document.getElementById('mLng').value);
   const file=document.getElementById('mFile').files[0];
+  const attachments = Array.from(document.getElementById('mAttachments')?.files || []);
   const msg=document.getElementById('markMsg');
   if(!nombre || !Number.isFinite(lat) || !Number.isFinite(lng)){ msg.textContent='Complete nombre y coordenadas válidas.'; return; }
   try{
-    if (file) beginBusy('Subiendo imagen', 100);
+    const totalUploads = (file?1:0) + attachments.length;
+    let uploadsDone = 0;
+    if (totalUploads){ beginBusy('Subiendo archivos', totalUploads); }
 
     let foto_url=null, foto_r2_key=null;
     if (file){
-      setBusyMsg('Subiendo imagen…');
+      setBusyMsg(`Subiendo imagen (${file.name})…`);
       const ext=(file.name.match(/\.[^.]+$/)?.[0]||'.jpg').toLowerCase();
       const keyPath=`marcaciones/${Date.now()}_${sanitizePath(file.name.replace(/\.[^.]+$/,''))}${ext}`;
       const up=await uploadToR2(R2_UPLOADER_URL, keyPath, file);
       foto_url=up.url; foto_r2_key=up.key;
-      setBusyProgress(100, 100, 'Imagen subida');
+      uploadsDone++;
+      if (totalUploads) setBusyProgress(uploadsDone, totalUploads, `Archivos ${uploadsDone}/${totalUploads}`);
     }
     const ewkt=`SRID=4326;POINT(${lng} ${lat})`;
     const body=[{ nombre, descripcion:descripcion||null, lat, lng, geom:ewkt, tipo:(file?tipo:null), foto_url, foto_r2_key }];
@@ -1030,6 +1211,40 @@ document.getElementById('markForm').addEventListener('submit', async (e)=>{
     const res=await fetch(url,{method:'POST',headers:{'apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${SUPABASE_ANON_KEY}`,'Content-Type':'application/json','Prefer':'return=representation'},body:JSON.stringify(body)});
     if(!res.ok){ const t=await res.text(); throw new Error(`HTTP ${res.status}: ${t}`); }
     const [row]=await res.json();
+
+    if (attachments.length){
+      const created = [];
+      for (let i=0;i<attachments.length;i++){
+        const att = attachments[i];
+        setBusyMsg(`Subiendo adjunto (${i+1}/${attachments.length})…`);
+        const keyPath=`marcaciones/${row.id}/adjuntos/${Date.now()}_${i}_${sanitizePath(att.name)}`;
+        const up = await uploadToR2(R2_UPLOADER_URL, keyPath, att);
+        const { data: inserted, error: attError } = await supabase
+          .from('marcaciones_adjuntos')
+          .insert({
+            marcacion_id: row.id,
+            nombre: att.name,
+            url: up.url,
+            r2_key: up.key,
+            content_type: att.type || null,
+            size: att.size ?? null
+          })
+          .select()
+          .single();
+        if (attError){
+          await deleteFromR2(R2_UPLOADER_URL, up.key);
+          throw new Error(attError.message || 'Error guardando adjunto');
+        }
+        created.push(inserted);
+        uploadsDone++;
+        if (totalUploads) setBusyProgress(uploadsDone, totalUploads, `Archivos ${uploadsDone}/${totalUploads}`);
+      }
+      row.adjuntos = created;
+      marcacionAdjuntosMap.set(row.id, created);
+    } else {
+      row.adjuntos = [];
+    }
+
     allMarcs.push(row);
     const m=addMarcacionMarker(row);
     if(m){ map.panTo(m.getLatLng()); m.openPopup(); }
@@ -1043,6 +1258,8 @@ document.getElementById('markForm').addEventListener('submit', async (e)=>{
     }
 
     msg.textContent='✅ Marcación guardada';
+    const newAttInput = document.getElementById('mAttachments');
+    if (newAttInput) newAttInput.value='';
     closeModal(markModal);
     markMode=false; document.getElementById('btnMark').textContent='➕ Marcar punto'; map._container.style.cursor='';
   }catch(err){ console.error(err); msg.textContent='Error: '+err.message; }
@@ -1062,8 +1279,15 @@ document.getElementById('editMarkForm').addEventListener('submit', async (e)=>{
 
   if(!nombre){ msg.textContent='Indica un nombre.'; return; }
 
+  const newAttachments = Array.from(document.getElementById('emAttachments')?.files || []);
+  const removeAttachmentIds = Array.from(document.querySelectorAll('#emAttachmentsList input[data-remove-id]:checked')).map(el=>Number(el.dataset.removeId)).filter(Boolean);
+
   try{
-    if (file) beginBusy('Subiendo imagen', 100); else beginBusy('Guardando cambios', 0);
+    const totalUploads = (file?1:0) + newAttachments.length;
+    const totalOps = totalUploads + removeAttachmentIds.length;
+    const busyLabel = totalOps ? 'Procesando archivos' : 'Guardando cambios';
+    beginBusy(busyLabel, totalOps);
+    let doneOps = 0;
 
     const patch = { nombre, descripcion: descripcion || null };
 
@@ -1080,10 +1304,12 @@ document.getElementById('editMarkForm').addEventListener('submit', async (e)=>{
         const up = await uploadToR2(R2_UPLOADER_URL, keyPath, file);
         patch.foto_url = up.url;
         patch.foto_r2_key = up.key;
-        setBusyProgress(100, 100, 'Imagen subida');
+        doneOps++;
+        if (totalOps) setBusyProgress(doneOps, totalOps, `Pasos ${doneOps}/${totalOps}`);
       }
     }
 
+    setBusyMsg('Guardando marcación…');
     const url = SUPABASE_URL.replace(/\/$/,'') + `/rest/v1/marcaciones?id=eq.${encodeURIComponent(id)}`;
     const res = await fetch(url, {
       method:'PATCH',
@@ -1099,17 +1325,69 @@ document.getElementById('editMarkForm').addEventListener('submit', async (e)=>{
 
     const [row] = await res.json();
 
+    if (removeAttachmentIds.length){
+      setBusyMsg('Eliminando adjuntos…');
+      for (const attId of removeAttachmentIds){
+        const currentList = marcacionAdjuntosMap.get(id) || [];
+        const attInfo = currentList.find(a=>a.id===attId);
+        const { error: delErr } = await supabase
+          .from('marcaciones_adjuntos')
+          .delete()
+          .eq('id', attId);
+        if (delErr) throw new Error(delErr.message || 'Error eliminando adjunto');
+        if (attInfo?.r2_key) await deleteFromR2(R2_UPLOADER_URL, attInfo.r2_key);
+        if (currentList.length){
+          marcacionAdjuntosMap.set(id, currentList.filter(a=>a.id!==attId));
+        }
+        doneOps++;
+        if (totalOps) setBusyProgress(doneOps, totalOps, `Pasos ${doneOps}/${totalOps}`);
+      }
+    }
+
+    if (newAttachments.length){
+      for (let i=0;i<newAttachments.length;i++){
+        const att = newAttachments[i];
+        setBusyMsg(`Subiendo adjunto (${i+1}/${newAttachments.length})…`);
+        const keyPath = `marcaciones/${id}/adjuntos/${Date.now()}_${i}_${sanitizePath(att.name)}`;
+        const up = await uploadToR2(R2_UPLOADER_URL, keyPath, att);
+        const { data: insertedAtt, error: attError } = await supabase
+          .from('marcaciones_adjuntos')
+          .insert({
+            marcacion_id: id,
+            nombre: att.name,
+            url: up.url,
+            r2_key: up.key,
+            content_type: att.type || null,
+            size: att.size ?? null
+          })
+          .select()
+          .single();
+        if (attError){
+          await deleteFromR2(R2_UPLOADER_URL, up.key);
+          throw new Error(attError.message || 'Error guardando adjunto');
+        }
+        const list = marcacionAdjuntosMap.get(id) || [];
+        list.unshift(insertedAtt);
+        marcacionAdjuntosMap.set(id, list);
+        doneOps++;
+        if (totalOps) setBusyProgress(doneOps, totalOps, `Pasos ${doneOps}/${totalOps}`);
+      }
+    }
+
     const i = allMarcs.findIndex(x=>x.id===id);
     if (i>=0) allMarcs[i] = row;
     await loadMarcaciones();
 
     msg.textContent = '✅ Guardado';
+    const editAttInput = document.getElementById('emAttachments');
+    if (editAttInput) editAttInput.value='';
     closeModal(document.getElementById('editMarkModal'));
 
-    document.getElementById('viewerTitle').textContent = `Marcación · ${row.nombre}`;
-    if (row.foto_r2_key || row.foto_url){
-      if (row.tipo === '360'){ await open360ForMarcacion(row); }
-      else { await openPhotoForMarcacion(row); }
+    const updatedRow = allMarcs.find(x=>x.id===id) || row;
+    document.getElementById('viewerTitle').textContent = `Marcación · ${updatedRow.nombre}`;
+    if (updatedRow.foto_r2_key || updatedRow.foto_url){
+      if (updatedRow.tipo === '360'){ await open360ForMarcacion(updatedRow); }
+      else { await openPhotoForMarcacion(updatedRow); }
     } else {
       showEmptyViewer();
     }

--- a/index.html
+++ b/index.html
@@ -165,6 +165,14 @@
           </div>
         </div>
 
+        <div class="form-row">
+          <div>
+            <div class="muted">Adjuntos (PDF, Excel, etc.)</div>
+            <input type="file" id="mAttachments" multiple>
+            <div class="muted" style="margin-top:4px">Puedes seleccionar varios archivos.</div>
+          </div>
+        </div>
+
         <div class="form-row cols-2">
           <div>
             <div class="muted">Lat *</div>
@@ -239,6 +247,21 @@
           </div>
         </div>
 
+        <div class="form-row">
+          <div>
+            <div class="muted">Adjuntos actuales</div>
+            <div id="emAttachmentsList" class="attachments-manage muted">—</div>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div>
+            <div class="muted">Agregar adjuntos</div>
+            <input type="file" id="emAttachments" multiple>
+            <div class="muted" style="margin-top:4px">Puedes seleccionar varios archivos.</div>
+          </div>
+        </div>
+
         <div class="actions">
           <button type="button" class="ghost" data-close>Cancelar</button>
           <button type="submit" class="pill">Guardar</button>
@@ -265,6 +288,22 @@
         </div>
       </form>
       <div id="editRecMsg" class="muted" style="margin-top:6px"></div>
+    </div>
+  </div>
+
+  <!-- Modal adjuntos marcación -->
+  <div id="attachmentsModal" class="modal" aria-hidden="true">
+    <div class="backdrop" data-close></div>
+    <div class="content attachments-modal">
+      <h3>Adjuntos de marcación</h3>
+      <div id="attachmentsContent" class="attachments-content">
+        <div id="attachmentsList" class="attachments-list"></div>
+        <div id="attachmentPreview" class="attachments-preview muted">Selecciona un adjunto para previsualizarlo.</div>
+      </div>
+      <div class="actions attachments-actions">
+        <button type="button" class="ghost" data-close>Cerrar</button>
+        <a id="attachmentDownload" class="pill" href="#" target="_blank" rel="noopener" style="display:none">⬇️ Descargar</a>
+      </div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -103,6 +103,38 @@ button, input, select, textarea{
 .muted{ color:#94a3b8; font-size:12px }
 .actions{ display:flex; gap:8px; justify-content:flex-end }
 
+/* Adjuntos marcaciones */
+.attachments-modal{ width:min(96vw,820px); display:flex; flex-direction:column; gap:14px; }
+.attachments-content{ display:flex; flex-direction:column; gap:12px; }
+.attachments-list{ display:flex; flex-direction:column; gap:6px; max-height:320px; overflow:auto; background:#0b1329; padding:10px; border-radius:10px; border:1px solid #1f2a44; }
+.attachments-item{ display:flex; align-items:center; gap:10px; padding:8px; border-radius:10px; border:1px solid transparent; background:rgba(15,23,42,.6); cursor:pointer; transition:background .2s ease, border-color .2s ease; }
+.attachments-item:hover{ background:rgba(14,165,233,.15); }
+.attachments-item.active{ border-color:#38bdf8; background:rgba(14,165,233,.25); }
+.attachments-item .name{ flex:1; font-size:14px; color:#e2e8f0; }
+.attachments-item .meta{ font-size:11px; color:#94a3b8; }
+.attachments-preview{ min-height:220px; border:1px dashed #1f2a44; border-radius:12px; display:flex; align-items:center; justify-content:center; padding:12px; background:#0b1224; }
+.attachments-preview iframe{ width:100%; height:360px; border:none; border-radius:10px; background:#111827; }
+.attachments-preview img{ max-width:100%; max-height:360px; border-radius:10px; box-shadow:0 10px 30px rgba(0,0,0,.35); }
+.attachments-preview .unavailable{ text-align:center; }
+.attachments-actions{ justify-content:space-between; align-items:center; }
+.attachments-actions .pill{ text-decoration:none; }
+.attachments-manage{ display:flex; flex-direction:column; gap:6px; padding:10px; border-radius:10px; border:1px solid #1f2a44; background:#0b1329; max-height:220px; overflow:auto; }
+.attachments-manage .item{ display:flex; align-items:center; justify-content:space-between; gap:10px; padding:6px 8px; border-radius:8px; border:1px solid rgba(148,163,184,.2); background:rgba(15,23,42,.7); }
+.attachments-manage .item label{ display:flex; align-items:center; gap:6px; font-size:12px; color:#e2e8f0; cursor:pointer; }
+.attachments-manage .item button{ border:none; background:none; color:#38bdf8; font-size:12px; cursor:pointer; padding:0; }
+.attachments-manage .empty{ font-style:italic; }
+.popup-attachments{ margin-top:6px; font-size:12px; }
+.popup-attachments .title{ color:#94a3b8; text-transform:uppercase; letter-spacing:.05em; display:block; margin-bottom:4px; }
+.popup-attachments-list{ display:flex; flex-direction:column; gap:4px; }
+.popup-attachments-list button{ border:none; background:none; color:#38bdf8; text-align:left; padding:0; font-size:12px; cursor:pointer; }
+.popup-attachments .view-all{ margin-top:6px; }
+
+@media (min-width:720px){
+  .attachments-content{ flex-direction:row; }
+  .attachments-list{ flex:0 0 280px; }
+  .attachments-preview{ flex:1; min-height:320px; }
+}
+
 /* Overlay de carga para el visor (foto / 360) */
 #viewerLoading{
   position:absolute; inset:0;


### PR DESCRIPTION
## Summary
- allow crear/editar marcaciones to adjuntar varios archivos y administrarlos desde el modal
- agregar estilos y modal de previsualización para adjuntos, incluyendo soporte para PDFs embebidos
- gestionar subidas/eliminaciones de adjuntos en el cliente y mostrar accesos directos desde los popups del mapa

## Testing
- not run (front-end only)

------
https://chatgpt.com/codex/tasks/task_e_6905ea0632c083228f206fef5146f211